### PR TITLE
fix broken link

### DIFF
--- a/content/zh/projects/sofa-boot/sofa-ark-ark-config/index.md
+++ b/content/zh/projects/sofa-boot/sofa-ark-ark-config/index.md
@@ -30,7 +30,7 @@ SOFAArk 的配置目录不是必须存在，如果需要，统一放在工程根
             └── logback-conf.xml
 ```
 
-**注意事项：如果应用中包含 SOFAArk 配置，打包时需要注意 baseDir 配置，用于指定工程根目录，具体[参考文档](../sofa-ark-ark-jar.md)**
+**注意事项：如果应用中包含 SOFAArk 配置，打包时需要注意 baseDir 配置，用于指定工程根目录，具体[参考文档](../sofa-ark-ark-jar)**
 
 上述 conf/ark 目录中可以配置 SOFAArk 容器启动配置以及日志配置，下面介绍配置的使用.
 

--- a/content/zh/projects/sofa-rpc/registry-sofa/index.md
+++ b/content/zh/projects/sofa-rpc/registry-sofa/index.md
@@ -5,7 +5,7 @@ aliases: "/sofa-rpc/docs/Registry-SOFA"
 ---
 
 
-SOFARPC 已支持使用 SOFARegistry 作为服务注册中心。假设你已经根据 SOFARegistry 的[快速开始](../../sofa-registry/getting-started-with-rpc)在本地部署好 SOFARegistry Server，服务发现的端口默认设置在 `9603`。
+SOFARPC 已支持使用 SOFARegistry 作为服务注册中心。假设你已经根据 SOFARegistry 的[快速开始](../../sofa-registry/server-quick-start)在本地部署好 SOFARegistry Server，服务发现的端口默认设置在 `9603`。
 
 在 SOFARPC 中使用 SOFARegistry 作为服务注册中心只需要在 application.properties 中加入如下配置即可：
 ```


### PR DESCRIPTION
In https://www.sofastack.tech/projects/sofa-rpc/registry-sofa/, it seems that https://www.sofastack.tech/projects/sofa-registry/getting-started-with-rpc no longer exists, so the link needs to be updated to https://www.sofastack.tech/projects/sofa-registry/server-quick-start/.

