### PR TITLE
fix: legacywebsite button

### DIFF
--- a/layouts/partials/back_legacy.html
+++ b/layouts/partials/back_legacy.html
@@ -1,4 +1,5 @@
-{{ if isset .Site.Params "legacyWebsite" }}
+{{/* https://gohugo.io/functions/isset/ */}}
+{{ if isset .Site.Params "legacywebsite" }}
 	<div class="ss-back-legacy">
 		<a
 			class="text{{if eq .Lang "en"}} english{{end}}"


### PR DESCRIPTION
[Hugo function isset](https://gohugo.io/functions/isset/)
`All site-level configuration keys are stored as lower case.` 

Close #50.