### PR TITLE
fix: disable taxonomyTerm page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,8 @@ defaultContentLanguageInSubdir = false
 hasCJKLanguage = true
 enableGitInfo = true
 
+disableKinds = ["taxonomyTerm"]
+
 Paginate = 10
 googleAnalytics = "UA-142131411-1"
 


### PR DESCRIPTION
#81 

We can temporary disable  taxonomyTerm page to fix this problem.

See [Turning off taxonomy pages](https://discourse.gohugo.io/t/turning-off-taxonomy-pages/2622/15).