### PR TITLE
FIX: pagination baseurl

### DIFF
--- a/assets/js/modules/pagination.js
+++ b/assets/js/modules/pagination.js
@@ -14,7 +14,16 @@ export default function() {
 
   const total = parseInt(dataset.total)
   const current = parseInt(dataset.current)
-  const baseurl = dataset.baseurl
+
+  /**
+   * example: 
+   * '/tags/sofa/page/1/ -> '/tags/sofa'
+   * */
+  const pathArr = location.pathname.split('/').filter(str => str !== "")
+  const pageIndex = pathArr.indexOf('page')
+  const basePathArr = pathArr.slice(0, pageIndex === -1 ? undefined : pageIndex)
+
+  const baseurl = basePathArr.join('/')
 
   const paginations = []
 

--- a/layouts/partials/pagination/pagination.html
+++ b/layouts/partials/pagination/pagination.html
@@ -1,10 +1,11 @@
 {{ $thisPagerNum := .Paginator.PageNumber }}
 
+{{ .File }}
+
 {{ if gt .Paginator.TotalPages 1 }}
 	<nav class="ss-pagination" 
 		data-total="{{ .Paginator.TotalPages }}" 
 		data-current="{{ .Paginator.PageNumber }}"
-		data-baseurl="{{ .Section }}"
 	>
 		<!-- see js/modeules/pagination.js -->
 	</nav>

--- a/layouts/partials/pagination/pagination.html
+++ b/layouts/partials/pagination/pagination.html
@@ -1,7 +1,5 @@
 {{ $thisPagerNum := .Paginator.PageNumber }}
 
-{{ .File }}
-
 {{ if gt .Paginator.TotalPages 1 }}
 	<nav class="ss-pagination" 
 		data-total="{{ .Paginator.TotalPages }}" 


### PR DESCRIPTION

The baseurl for pagination component maybe not equal to `.Section` 
Like url `/tags/sofa/page/2`，the baseurl should be `/tags/sofa`，not `/tags`


fix #224 