### PR TITLE
feat: video shortcode

### DIFF
--- a/assets/sass/partials/post/markdown.scss
+++ b/assets/sass/partials/post/markdown.scss
@@ -292,6 +292,7 @@
   max-width: 100%;
   margin-top: 24px;
   margin-bottom: 24px;
+  outline: none;
 }
 
 .typo img {

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -1,0 +1,4 @@
+
+<!-- video shortcode, only support NamedParams -->
+
+<video src="{{.Get "src" }}" controls {{ if .Get "autoplay" }}autoplay{{ end }} />


### PR DESCRIPTION
增加 markdown 嵌入视频的支持

#### 使用示例

```
{{< video src="https://gw.alipayobjects.com/mdn/rms_91f3e6/afts/file/A*aLSCTI2VVX8AAAAAAAAAAABkARQnAQ" >}}

{{< video src="http://xxxxxx" autoplay="true" >}}
```

#### 参数

`src` 视频地址

`autoplay` 视频是否自动播放


