### PR TITLE
docs: 修复文档序号错乱

### DIFF
--- a/content/zh/projects/sofa-rpc/getting-started-with-sofa-boot/index.md
+++ b/content/zh/projects/sofa-rpc/getting-started-with-sofa-boot/index.md
@@ -31,7 +31,8 @@ aliases: "/sofa-rpc/docs/Getting-Started-with-SOFA-Boot"
 </parent>
 ```
 
-这里的 `${sofa-boot.version}` 指定具体的 SOFABoot 版本，参考[发布历史](https://github.com/sofastack/sofa-boot/releases)
+这里的 `${sofa-boot.version}` 指定具体的 SOFABoot 版本，参考[发布历史](https://github.com/sofastack/sofa-boot/releases)。
+
 4. 配置 application.properties ：application.properties 是 SOFABoot 工程中的配置文件。这里需要配置一个必不可少的配置项，即应用名。
 
 ```xml


### PR DESCRIPTION
在这个页面 【SOFABoot 方式快速入门】https://www.sofastack.tech/projects/sofa-rpc/getting-started-with-sofa-boot/ 的【创建工程】部分， 渲染出来的序号与预期不符，原因为序号3的结束部分没有正确换行：


![image](https://github.com/sofastack/sofastack.tech/assets/12819457/fd61c939-8b07-45d8-898d-ec2fc988acd7)
