### PR TITLE
docs(ark-telnet): document telnet JVM config options (enable/port/security)

### DIFF
--- a/content/zh/projects/sofa-boot/sofa-ark-ark-config/index.md
+++ b/content/zh/projects/sofa-boot/sofa-ark-ark-config/index.md
@@ -35,6 +35,7 @@ SOFAArk 的配置目录不是必须存在，如果需要，统一放在工程根
 conf/ark/bootstrap.properties 是 SOFAArk 容器默认启动配置文件，配置内容包括：日志配置、plugin 激活和钝化配置、biz 激活和钝化配置.
 
 ### 日志配置
+
 SOFAArk 容器日志内部实现使用 logback,  日志配置参数包括：
 + logging.path 
 > 容器日志目录根路径，这里只影响 SOFAArk 容器日志路径，不影响应用日志，应用自身日志由自身配置决定，默认打印在 ${user.admin}/logs 目录
@@ -51,7 +52,8 @@ SOFAArk 容器日志内部实现使用 logback,  日志配置参数包括：
 + sofa.middleware.log.com.alipay.sofa.ark.console.level
 > 配合上述配置项使用，如果打印在 console ，该配置项用于配置 SOFAArk 容器打印在 console 的日志级别
 
-### 插件配置 
+### 插件配置
+
 + ark.plugin.active.include
 > 指定激活哪些插件，多个插件使用 ',' 分隔；默认激活 Ark 包中所有的插件。
 
@@ -61,6 +63,7 @@ SOFAArk 容器日志内部实现使用 logback,  日志配置参数包括：
 **注：如果同时配置了这两个属性，以 ark.plugin.active.include 为准**
 
 ### biz配置
+
 + ark.biz.active.include
 > 指定激活哪些 Biz，多个 Biz 使用 ',' 分隔；默认激活 Ark 包中所有的 Biz.
 
@@ -72,8 +75,14 @@ SOFAArk 容器日志内部实现使用 logback,  日志配置参数包括：
 
 **注：如果同时配置了前两个属性，以 ark.biz.active.include 为准**
 
+### Telnet 配置
+
+容器内置 Telnet 服务端的相关 JVM 参数也在 `bootstrap.properties` 中配置，包括 `sofa.ark.telnet.server.enable`、`sofa.ark.telnet.port`、`sofa.ark.telnet.security.enable`，具体含义与安全建议请参考 [Telnet 指令](../sofa-ark-ark-telnet)。
+
 ### 动态配置
+
 SOFAArk 提供了对接 Zookeeper 的插件，目前用于动态接收 Biz 指令，目前只支持 Zookeeper，配置格式如下：
+
 ```text
 com.alipay.sofa.ark.config.address=zookeeper://ip:port?key1=value1&key2=value2
 ```
@@ -81,6 +90,7 @@ com.alipay.sofa.ark.config.address=zookeeper://ip:port?key1=value1&key2=value2
 **特别注意，SOFAArk 有一个默认的逻辑，如果用户配置了 `com.alipay.sofa.ark.config.address`，且 Ark 包中打入了多个 Biz，则只会启动宿主应用(master biz)；这样做的原因是如果配置了动态配置，SOFAArk 会优先根据动态配置控制 Biz 的部署。**
 
 ### Profile 机制
+
 默认 SOFAArk 容器使用 bootstrap.properties 配置，实际开发中，可能根据运行环境加载不同的配置，SOFAArk 提供了 profile 机制. 指定 profile 值，SOFAArk 容器会加载 bootstrap-${profile}.properties 配置文件。指定 profile 的配置有两种方式：
 + 通过 -D  VM 参数传入，例如：-Dark.profile=dev,dev2  多个值使用 ',' 隔开。
 + 通过应用启动参数传入，例如：java -jar demo-executable-ark.jar -Aprofile=dev,dev2 多个值使用 ',' 隔开。

--- a/content/zh/projects/sofa-boot/sofa-ark-ark-telnet/index.md
+++ b/content/zh/projects/sofa-boot/sofa-ark-ark-telnet/index.md
@@ -4,11 +4,24 @@ title: "Telnet 指令"
 aliases: "/sofa-boot/docs/sofa-ark-ark-telnet"
 ---
 
-
 SOFAArk 容器提供了一个简单的 telnet 服务端小工具，用于运行时查看容器状态，目前支持查看 Plugin 和 Biz 相关信息。
 
+### 配置参数
+
+SOFAArk Telnet 服务端支持通过 JVM 参数（`-D`）或 `bootstrap.properties` 配置以下参数：
+
++ sofa.ark.telnet.server.enable
+> 是否启用 Telnet 服务端，默认为 `true`。生产环境若无需运行时查看，建议设为 `false` 直接关闭，避免暴露运行时入口。
+
++ sofa.ark.telnet.port
+> Telnet 监听端口，默认为 `1234`。未指定时会在以 `1234` 起始的端口范围内自动选择可用端口（最多尝试 100 个）。
+
++ sofa.ark.telnet.security.enable
+> 是否开启安全模式，默认为 `false`。开启后将进行两重限制：仅允许 `localhost` 来源的连接，并禁用 `biz -i`（install）、`biz -u`（uninstall）等写操作命令。生产环境建议开启。
+
 ### 使用方式
-使用 telnet 连接服务端，端口号为 1234， 例如：
+
+使用 telnet 连接服务端，默认端口为 1234（可通过 `sofa.ark.telnet.port` 修改），例如：
 
 > telnet localhost 1234
 
@@ -54,6 +67,7 @@ sofa-ark>
 ```
 
 ### Plugin 命令
+
 如提示信息所说，plugin 支持查看插件相关信息，包括类(资源)导入导出配置、插件打包配置等。例如：
 
 ```text
@@ -81,6 +95,7 @@ sofa-ark>
 其他命令可以查看提示信息，暂时不支持 `-s` 选项查看服务。
 
 ### Biz 命令
+
 biz 命令支持查看 biz 相关信息，也支持安装、卸载、激活等 biz 操作指令。例如
 
 ```text


### PR DESCRIPTION
## 背景
SOFAArk Telnet 服务端支持三个 JVM 配置参数（`-D` 或 `bootstrap.properties`），但文档站此前完全没有记录，读者无法得知如何修改端口、关闭服务端或开启安全模式。

## 改动
- `sofa-ark-ark-telnet/index.md`：新增「配置参数」小节，说明 `sofa.ark.telnet.server.enable` / `sofa.ark.telnet.port` / `sofa.ark.telnet.security.enable`
的默认值与作用；并修正「使用方式」中硬写的端口号说明。
- `sofa-ark-ark-config/index.md`：新增「Telnet 配置」索引行，链回 telnet 文档，避免配置总览遗漏这几个参数。

## 说明
- 参数语义依据 sofa-ark 源码 `Constants.java` / `StandardTelnetServerImpl.java` / `EnvironmentUtils.java` / `NettyTelnetServer.java`。
- 仅改动 `zh` 目录；`en` 站目前不存在对应文档（英文站长期未同步），本次不扩大范围。